### PR TITLE
Wayfinder Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_rds"></a> [rds](#module\_rds) | terraform-aws-modules/rds/aws | 4.4.0 |
+| <a name="module_rds"></a> [rds](#module\_rds) | terraform-aws-modules/rds/aws | 5.0.3 |
 
 ## Resources
 
@@ -28,8 +28,14 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_backup_retention_period"></a> [backup\_retention\_period](#input\_backup\_retention\_period) | The number of days to keep backups for | `number` | `1` | no |
+| <a name="input_database_backup_window"></a> [database\_backup\_window](#input\_database\_backup\_window) | The time window you want to perform maintenance in | `string` | `"03:00-06:00"` | no |
+| <a name="input_database_engine"></a> [database\_engine](#input\_database\_engine) | The database engine you want to use, i.e MySQL, Postgres, etc | `string` | `"mysql"` | no |
+| <a name="input_database_engine_version"></a> [database\_engine\_version](#input\_database\_engine\_version) | The version of the database engine you want to use | `string` | `"5.7.25"` | no |
+| <a name="input_database_family"></a> [database\_family](#input\_database\_family) | The family of the database engine you want to use | `string` | `"mysql5.7"` | no |
+| <a name="input_database_major_engine_version"></a> [database\_major\_engine\_version](#input\_database\_major\_engine\_version) | The major version of the database engine you want to use | `string` | `"5.7"` | no |
+| <a name="input_database_options"></a> [database\_options](#input\_database\_options) | The time window you want to perform maintenance in | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | n/a | yes |
+| <a name="input_database_parameters"></a> [database\_parameters](#input\_database\_parameters) | The options you want to use for the database | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | <pre>[<br>  {<br>    "name": "character_set_client",<br>    "value": "utf8mb4"<br>  },<br>  {<br>    "name": "character_set_server",<br>    "value": "utf8mb4"<br>  }<br>]</pre> | no |
 | <a name="input_database_password"></a> [database\_password](#input\_database\_password) | The database password to use for this database | `string` | `""` | no |
-| <a name="input_database_username"></a> [database\_username](#input\_database\_username) | The username to create when provisioning the database | `string` | `"root"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The name of the environment you are provisioning in | `string` | n/a | yes |
 | <a name="input_instance"></a> [instance](#input\_instance) | The instance defines the instance class which should be used by the database | `string` | `"db.t3.medium"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the database you want to create | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.29.0 |
 
 ## Modules
 
@@ -28,14 +28,17 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_backup_retention_period"></a> [backup\_retention\_period](#input\_backup\_retention\_period) | The number of days to keep backups for | `number` | `1` | no |
-| <a name="input_database_backup_window"></a> [database\_backup\_window](#input\_database\_backup\_window) | The time window you want to perform maintenance in | `string` | `"03:00-06:00"` | no |
-| <a name="input_database_engine"></a> [database\_engine](#input\_database\_engine) | The database engine you want to use, i.e MySQL, Postgres, etc | `string` | `"mysql"` | no |
-| <a name="input_database_engine_version"></a> [database\_engine\_version](#input\_database\_engine\_version) | The version of the database engine you want to use | `string` | `"5.7.25"` | no |
+| <a name="input_database_backup_window"></a> [database\_backup\_window](#input\_database\_backup\_window) | The time window you want to perform maintenance in | `string` | `"01:00-03:00"` | no |
+| <a name="input_database_engine"></a> [database\_engine](#input\_database\_engine) | The database engine you want to use i.e mysql, postgres, etc | `string` | `"mysql"` | no |
+| <a name="input_database_engine_version"></a> [database\_engine\_version](#input\_database\_engine\_version) | The version of the database engine you want to use | `string` | `"5.7.33"` | no |
 | <a name="input_database_family"></a> [database\_family](#input\_database\_family) | The family of the database engine you want to use | `string` | `"mysql5.7"` | no |
+| <a name="input_database_maintenance_window"></a> [database\_maintenance\_window](#input\_database\_maintenance\_window) | The time window you want to perform maintenance in | `string` | `"Mon:04:00-Mon:06:00"` | no |
 | <a name="input_database_major_engine_version"></a> [database\_major\_engine\_version](#input\_database\_major\_engine\_version) | The major version of the database engine you want to use | `string` | `"5.7"` | no |
-| <a name="input_database_options"></a> [database\_options](#input\_database\_options) | The time window you want to perform maintenance in | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | n/a | yes |
+| <a name="input_database_options"></a> [database\_options](#input\_database\_options) | The time window you want to perform maintenance in | <pre>list(object({<br>    option_name = string<br>    option_settings = list(object({<br>      name  = string<br>      value = string<br>    }))<br>  }))</pre> | <pre>[<br>  {<br>    "option_name": "MARIADB_AUDIT_PLUGIN",<br>    "option_settings": [<br>      {<br>        "name": "SERVER_AUDIT_FILE_ROTATIONS",<br>        "value": "37"<br>      },<br>      {<br>        "name": "SERVER_AUDIT_EVENTS",<br>        "value": "CONNECT"<br>      }<br>    ]<br>  }<br>]</pre> | no |
 | <a name="input_database_parameters"></a> [database\_parameters](#input\_database\_parameters) | The options you want to use for the database | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | <pre>[<br>  {<br>    "name": "character_set_client",<br>    "value": "utf8mb4"<br>  },<br>  {<br>    "name": "character_set_server",<br>    "value": "utf8mb4"<br>  }<br>]</pre> | no |
 | <a name="input_database_password"></a> [database\_password](#input\_database\_password) | The database password to use for this database | `string` | `""` | no |
+| <a name="input_database_port"></a> [database\_port](#input\_database\_port) | The port the database should listen on | `number` | `3306` | no |
+| <a name="input_database_username"></a> [database\_username](#input\_database\_username) | The username you want to use for the database | `string` | `"root"` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The name of the environment you are provisioning in | `string` | n/a | yes |
 | <a name="input_instance"></a> [instance](#input\_instance) | The instance defines the instance class which should be used by the database | `string` | `"db.t3.medium"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the database you want to create | `string` | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -1,100 +1,73 @@
-
 data "aws_vpc" "selected" {
   filter {
-    name   = "tag:Environment"
-    values = [var.environment]
+    name   = "tag:Name"
+    values = [var.name]
+  }
+
+  filter {
+    name   = "tag:appvia.io/managed"
+    values = ["true"]
   }
 }
 
 data "aws_subnets" "selected" {
   filter {
-    name   = "tag:Database"
-    values = ["true"]
-  }
-
-  filter {
-    name   = "tag:Environment"
-    values = [var.environment]
-  }
-
-  filter {
     name   = "vpc-id"
     values = [data.aws_vpc.selected.id]
+  }
+
+  filter {
+    name   = "tag:Name"
+    values = [var.name]
+  }
+
+  filter {
+    name   = "tag:Network"
+    values = ["Private"]
+  }
+
+  filter {
+    name   = "tag:appvia.io/managed"
+    values = ["true"]
   }
 }
 
 data "aws_security_groups" "selected" {
   filter {
-    name   = "tag:Environment"
-    values = [var.environment]
-  }
-
-  filter {
-    name   = "tag:Name"
-    values = [format("terranetes-%s-db-sg", var.environment)]
-  }
-
-  filter {
     name   = "vpc-id"
     values = [data.aws_vpc.selected.id]
+  }
+
+  filter {
+    name   = "tag:aws:eks:cluster-name"
+    values = [var.name]
   }
 }
 
 module "rds" {
   source  = "terraform-aws-modules/rds/aws"
-  version = "4.4.0"
+  version = "5.0.3"
 
-  identifier        = var.name
-  engine            = "mysql"
-  engine_version    = "5.7.25"
-  instance_class    = var.instance
-  allocated_storage = var.storage
-
-  db_name                 = var.name
-  username                = var.database_username
-  password                = var.database_password
-  port                    = "3306"
-  backup_window           = "03:00-06:00"
+  allocated_storage       = var.storage
   backup_retention_period = var.backup_retention_period
-  maintenance_window      = "Mon:00:00-Mon:03:00"
+  backup_window           = var.database_backup_window
+  create_db_subnet_group  = true
+  db_name                 = var.name
+  db_subnet_group_name    = format("%s-db-group", var.name)
+  deletion_protection     = false
+  engine                  = var.database_engine
+  engine_version          = var.database_engine_version
+  family                  = var.database_family
+  identifier              = var.name
+  instance_class          = var.instance
+  maintenance_window      = var.database_maintenance_window
+  major_engine_version    = var.database_major_engine_version
+  options                 = var.database_options
+  parameters              = var.database_parameters
+  password                = var.database_password
+  port                    = var.database_port
   skip_final_snapshot     = true
+  subnet_ids              = data.aws_subnets.selected.ids
+  username                = var.database_username
   vpc_security_group_ids  = data.aws_security_groups.selected.ids
-
-  tags = {
-    Environment = var.environment
-  }
-
-  create_db_subnet_group = false
-  db_subnet_group_name   = format("terranetes-%s-db", var.environment)
-  deletion_protection    = false
-  family                 = "mysql5.7"
-  major_engine_version   = "5.7"
-  subnet_ids             = data.aws_subnets.selected.ids
-
-  parameters = [
-    {
-      name  = "character_set_client"
-      value = "utf8mb4"
-    },
-    {
-      name  = "character_set_server"
-      value = "utf8mb4"
-    }
-  ]
-
-  options = [
-    {
-      option_name = "MARIADB_AUDIT_PLUGIN"
-      option_settings = [
-        {
-          name  = "SERVER_AUDIT_FILE_ROTATIONS"
-          value = "37"
-        },
-        {
-          name  = "SERVER_AUDIT_EVENTS"
-          value = "CONNECT"
-        },
-      ]
-    },
-  ]
 }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 data "aws_vpc" "selected" {
   filter {
     name   = "tag:Name"
-    values = [var.name]
+    values = [var.environment]
   }
 
   filter {
@@ -18,7 +18,7 @@ data "aws_subnets" "selected" {
 
   filter {
     name   = "tag:Name"
-    values = [var.name]
+    values = [var.environment]
   }
 
   filter {
@@ -40,7 +40,7 @@ data "aws_security_groups" "selected" {
 
   filter {
     name   = "tag:aws:eks:cluster-name"
-    values = [var.name]
+    values = [var.environment]
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -17,11 +17,6 @@ data "aws_subnets" "selected" {
   }
 
   filter {
-    name   = "tag:Name"
-    values = [var.environment]
-  }
-
-  filter {
     name   = "tag:Network"
     values = ["Private"]
   }

--- a/variables.tf
+++ b/variables.tf
@@ -20,10 +20,75 @@ variable "storage" {
   default     = 10
 }
 
-variable "database_username" {
-  description = "The username to create when provisioning the database"
+variable "database_engine" {
+  description = "The database engine you want to use, i.e MySQL, Postgres, etc"
   type        = string
-  default     = "root"
+  default     = "mysql"
+}
+
+variable "database_engine_version" {
+  description = "The version of the database engine you want to use"
+  type        = string
+  default     = "5.7.25"
+}
+
+variable "database_family" {
+  description = "The family of the database engine you want to use"
+  type        = string
+  default     = "mysql5.7"
+}
+
+variable "database_backup_window" {
+  description = "The time window you want to perform maintenance in"
+  type        = string
+  default     = "03:00-06:00"
+}
+
+variable "database_major_engine_version" {
+  description = "The major version of the database engine you want to use"
+  type        = string
+  default     = "5.7"
+}
+
+variable "database_options" {
+  description = "The time window you want to perform maintenance in"
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  dafault = [
+    {
+      option_name = "MARIADB_AUDIT_PLUGIN"
+      option_settings = [
+        {
+          name  = "SERVER_AUDIT_FILE_ROTATIONS"
+          value = "37"
+        },
+        {
+          name  = "SERVER_AUDIT_EVENTS"
+          value = "CONNECT"
+        },
+      ]
+    },
+  ]
+}
+
+variable "database_parameters" {
+  description = "The options you want to use for the database"
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default = [
+    {
+      name  = "character_set_client"
+      value = "utf8mb4"
+    },
+    {
+      name  = "character_set_server"
+      value = "utf8mb4"
+    }
+  ]
 }
 
 variable "database_password" {

--- a/variables.tf
+++ b/variables.tf
@@ -29,7 +29,7 @@ variable "database_engine" {
 variable "database_engine_version" {
   description = "The version of the database engine you want to use"
   type        = string
-  default     = "5.7.25"
+  default     = "5.7.33"
 }
 
 variable "database_family" {
@@ -115,11 +115,11 @@ variable "backup_retention_period" {
 variable "database_backup_window" {
   description = "The time window you want to perform maintenance in"
   type        = string
-  default     = "03:00-06:00"
+  default     = "01:00-03:00"
 }
 
 variable "database_maintenance_window" {
   description = "The time window you want to perform maintenance in"
   type        = string
-  default     = "Mon:03:00-Mon:06:00"
+  default     = "Mon:04:00-Mon:06:00"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,7 @@ variable "storage" {
 }
 
 variable "database_engine" {
-  description = "The database engine you want to use, i.e MySQL, Postgres, etc"
+  description = "The database engine you want to use i.e mysql, postgres, etc"
   type        = string
   default     = "mysql"
 }
@@ -38,25 +38,28 @@ variable "database_family" {
   default     = "mysql5.7"
 }
 
-variable "database_backup_window" {
-  description = "The time window you want to perform maintenance in"
-  type        = string
-  default     = "03:00-06:00"
-}
-
 variable "database_major_engine_version" {
   description = "The major version of the database engine you want to use"
   type        = string
   default     = "5.7"
 }
 
+variable "database_port" {
+  description = "The port the database should listen on"
+  type        = number
+  default     = 3306
+}
+
 variable "database_options" {
   description = "The time window you want to perform maintenance in"
   type = list(object({
-    name  = string
-    value = string
+    option_name = string
+    option_settings = list(object({
+      name  = string
+      value = string
+    }))
   }))
-  dafault = [
+  default = [
     {
       option_name = "MARIADB_AUDIT_PLUGIN"
       option_settings = [
@@ -91,6 +94,12 @@ variable "database_parameters" {
   ]
 }
 
+variable "database_username" {
+  description = "The username you want to use for the database"
+  type        = string
+  default     = "root"
+}
+
 variable "database_password" {
   description = "The database password to use for this database"
   type        = string
@@ -101,4 +110,16 @@ variable "backup_retention_period" {
   description = "The number of days to keep backups for"
   type        = number
   default     = 1
+}
+
+variable "database_backup_window" {
+  description = "The time window you want to perform maintenance in"
+  type        = string
+  default     = "03:00-06:00"
+}
+
+variable "database_maintenance_window" {
+  description = "The time window you want to perform maintenance in"
+  type        = string
+  default     = "Mon:03:00-Mon:06:00"
 }


### PR DESCRIPTION
Making the changes required to work with a default installation
of a Wayfinder cluster built on AWS.

Requires that the `environment` variable is set to the cluster name or a policy is used to inject it i.e. 

```yaml
apiVersion: terraform.appvia.io/v1alpha1
kind: Policy
metadata:
  name: environment-defaults
spec:
  defaults:
    - variables:
        environment: <CLUSTER_NAME>
```


